### PR TITLE
Discarding the master-slave words

### DIFF
--- a/Godeps/_workspace/src/github.com/asaskevich/govalidator/types.go
+++ b/Godeps/_workspace/src/github.com/asaskevich/govalidator/types.go
@@ -336,7 +336,7 @@ var ISO3166List = []ISO3166Entry{
 	{"Tuvalu", "Tuvalu (les)", "TV", "TUV", "798"},
 	{"Uganda", "Ouganda (l')", "UG", "UGA", "800"},
 	{"Ukraine", "Ukraine (l')", "UA", "UKR", "804"},
-	{"Macedonia (the former Yugoslav Republic of)", "Macédoine (l'ex‑République yougoslave de)", "MK", "MKD", "807"},
+	{"Macedonia (the former Yugoslav Republic of)", "Macédoine (l'ex‑République yougosubordinate de)", "MK", "MKD", "807"},
 	{"Egypt", "Égypte (l')", "EG", "EGY", "818"},
 	{"United Kingdom of Great Britain and Northern Ireland (the)", "Royaume-Uni de Grande-Bretagne et d'Irlande du Nord (le)", "GB", "GBR", "826"},
 	{"Guernsey", "Guernesey", "GG", "GGY", "831"},

--- a/config/config.go
+++ b/config/config.go
@@ -32,8 +32,8 @@ type (
 	// Postgres structure
 	Postgres struct {
 		Database string       `json:"database"`
-		Master   PostgresDB   `json:"master"`
-		Slaves   []PostgresDB `json:"slaves"`
+		Main   PostgresDB   `json:"main"`
+		Subordinates   []PostgresDB `json:"subordinates"`
 	}
 
 	// Config structure for the application configuration

--- a/mailer/vendor/guzzle/guzzle/docs/conf.py
+++ b/mailer/vendor/guzzle/guzzle/docs/conf.py
@@ -11,7 +11,7 @@ primary_domain = 'php'
 extensions = []
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 project = u'Guzzle'
 copyright = u'2012, Michael Dowling'

--- a/server/default_routes.go
+++ b/server/default_routes.go
@@ -172,21 +172,21 @@ func healthCheckHandler(ctx *context.Context) {
 	response := struct {
 		Healthy  bool `json:"healthy"`
 		Services struct {
-			PostgresMaster bool   `json:"postgres_master"`
-			PostgresSlaves []bool `json:"postgres_slaves"`
+			PostgresMain bool   `json:"postgres_main"`
+			PostgresSubordinates []bool `json:"postgres_subordinates"`
 			RateLimiter    bool   `json:"rate_limiter"`
 			AppCache       bool   `json:"app_cache"`
 		} `json:"services"`
 	}{
 		Healthy: true,
 		Services: struct {
-			PostgresMaster bool   `json:"postgres_master"`
-			PostgresSlaves []bool `json:"postgres_slaves"`
+			PostgresMain bool   `json:"postgres_main"`
+			PostgresSubordinates []bool `json:"postgres_subordinates"`
 			RateLimiter    bool   `json:"rate_limiter"`
 			AppCache       bool   `json:"app_cache"`
 		}{
-			PostgresMaster: true,
-			PostgresSlaves: make([]bool, rawPostgresClient.SlaveCount()),
+			PostgresMain: true,
+			PostgresSubordinates: make([]bool, rawPostgresClient.SubordinateCount()),
 			RateLimiter:    true,
 			AppCache:       true,
 		},
@@ -208,16 +208,16 @@ func healthCheckHandler(ctx *context.Context) {
 	// Check Postgres
 	if _, err := rawPostgresClient.MainDatastore().Exec("SELECT 1"); err != nil {
 		response.Healthy = false
-		response.Services.PostgresMaster = false
+		response.Services.PostgresMain = false
 	}
 
-	// TODO add exactly the slaves
-	for slave := 0; slave < rawPostgresClient.SlaveCount(); slave++ {
-		if _, err := rawPostgresClient.SlaveDatastore(slave).Exec("SELECT 1"); err != nil {
+	// TODO add exactly the subordinates
+	for subordinate := 0; subordinate < rawPostgresClient.SubordinateCount(); subordinate++ {
+		if _, err := rawPostgresClient.SubordinateDatastore(subordinate).Exec("SELECT 1"); err != nil {
 			response.Healthy = false
-			response.Services.PostgresSlaves[slave] = false
+			response.Services.PostgresSubordinates[subordinate] = false
 		} else {
-			response.Services.PostgresSlaves[slave] = true
+			response.Services.PostgresSubordinates[subordinate] = true
 		}
 	}
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.